### PR TITLE
Fix SyntaxWarning when running kernel install script in Python 3.12+

### DIFF
--- a/nbs/04_code_utils.ipynb
+++ b/nbs/04_code_utils.ipynb
@@ -850,7 +850,7 @@
     "    code = _replace_delimiter(code, sc_delimiter) \n",
     "    \n",
     "    # Replace multiple interior whitespace with one\n",
-    "    code = multi_regex.sub('\\g<char> ',code)\n",
+    "    code = multi_regex.sub(r'\\g<char> ',code)\n",
     "    \n",
     "    # Delete blank lines and whitespace at end of lines\n",
     "    code_lines = code.splitlines()\n",

--- a/nbs/09_magics.ipynb
+++ b/nbs/09_magics.ipynb
@@ -1100,7 +1100,7 @@
     "#| export\n",
     "@patch_to(StataMagics)\n",
     "def magic_help(self, code, kernel, cell):\n",
-    "    \"\"\"Show help file from stata.com/help.cgi?\\{\\}\"\"\"\n",
+    "    r\"\"\"Show help file from stata.com/help.cgi?{}\"\"\"\n",
     "    try:\n",
     "        html_help = self._get_help_html(code)\n",
     "    except Exception as e: # original: (urllib.error.HTTPError, urllib.error.URLError)\n",

--- a/nbstata/code_utils.py
+++ b/nbstata/code_utils.py
@@ -118,7 +118,7 @@ def standardize_code(code, sc_delimiter=False):
     code = _replace_delimiter(code, sc_delimiter) 
     
     # Replace multiple interior whitespace with one
-    code = multi_regex.sub('\g<char> ',code)
+    code = multi_regex.sub(r'\g<char> ',code)
     
     # Delete blank lines and whitespace at end of lines
     code_lines = code.splitlines()

--- a/nbstata/magics.py
+++ b/nbstata/magics.py
@@ -428,7 +428,7 @@ def _get_help_html(self, code):
 # %% ../nbs/09_magics.ipynb 56
 @patch_to(StataMagics)
 def magic_help(self, code, kernel, cell):
-    """Show help file from stata.com/help.cgi?\{\}"""
+    r"""Show help file from stata.com/help.cgi?{}"""
     try:
         html_help = self._get_help_html(code)
     except Exception as e: # original: (urllib.error.HTTPError, urllib.error.URLError)


### PR DESCRIPTION
Thanks indeed for this amazing kernel.

Hopefully the first of my commits here fixes the SyntaxWarning which currently occurs when using Python 3.12 or later when running the kernel install script. The warning looks as follows.
```
$ python -m nbstata.install --sys-prefix
.venv/lib/python3.13/site-packages/nbstata/code_utils.py:121: SyntaxWarning: invalid escape sequence '\g'
  code = multi_regex.sub('\g<char> ',code)
Installing Jupyter kernel spec
```

The second commit fixes a SyntaxWarning, again in Python 3.12+ when running the tests (with `nbdev_prepare`).

(PS. Also there are two uses of `pkg_resources` in this (in _setup.py_ and _nbs/09_magics.ipynb_ [and hence also in _nbstata/magics.py_]) which might need updating soon also.)