### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,5 +1,7 @@
 name: CI
 on:  [workflow_dispatch, pull_request, push]
+permissions:
+  contents: read
 
 jobs:
   test:


### PR DESCRIPTION
Potential fix for [https://github.com/hugetim/nbstata/security/code-scanning/1](https://github.com/hugetim/nbstata/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block that restricts the permissions of the GITHUB_TOKEN for this workflow/job. Since the job appears to run tests via `fastai/workflows/nbdev-ci@master`, the minimal permissions required are typically `contents: read`. If the workflow requires writing pull requests or issues (to provide feedback or status), then you can increase those permissions, but the minimal safe starting point is `contents: read`. The most direct way is to insert this block either at the root (applies to all jobs) or at the job level. Insert after the `on:` statement, before `jobs:`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
