### PR TITLE
Fix: Replace deprecated pkg_resources with os.path

### DIFF
--- a/nbs/09_magics.ipynb
+++ b/nbs/09_magics.ipynb
@@ -44,9 +44,9 @@
     "from nbstata.stata_session import warn_re_unclosed_comment_block_if_needed\n",
     "import nbstata.browse as browse\n",
     "from fastcore.basics import patch_to\n",
+    "import os\n",
     "import re\n",
     "import urllib\n",
-    "from pkg_resources import resource_filename\n",
     "from bs4 import BeautifulSoup as bs\n",
     "import configparser"
    ]
@@ -161,9 +161,7 @@
     "    \n",
     "    abbrev_dict = _construct_abbrev_dict()\n",
     "    \n",
-    "    csshelp_default = resource_filename(\n",
-    "        'nbstata', 'css/_StataKernelHelpDefault.css'\n",
-    "    )\n",
+    "    csshelp_default = os.path.join(os.path.dirname(__file__), 'css', '_StataKernelHelpDefault.css')\n",
     "\n",
     "    def magic_quietly(self, code, kernel, cell):\n",
     "        \"\"\"Suppress all display for the current cell.\"\"\"\n",


### PR DESCRIPTION
This PR addresses the `DeprecationWarning` related to `pkg_resources` when running `nbstata` in newer environments.

Since `pkg_resources` is slated for removal and triggers warnings in `setuptools`, I have replaced `resource_filename` with standard `os.path` operations to locate the CSS file. This change removes the runtime warning and reduces dependencies.