### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,6 +7,9 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/hugetim/nbstata/security/code-scanning/3](https://github.com/hugetim/nbstata/security/code-scanning/3)

In general, the fix is to explicitly declare a `permissions:` block to limit the `GITHUB_TOKEN` for this workflow to the minimal scopes needed. This job only checks out code and runs tests, so it only needs read access to repository contents. We can therefore add `permissions: contents: read` at the workflow root so it applies to all jobs (there is only one job, `tests`).

The best targeted fix without changing functionality is to insert, near the top of `.github/workflows/test.yaml`, a `permissions:` section with `contents: read`. Placing it after the `on:` block (and before `jobs:`) is idiomatic and ensures the setting applies to all jobs that don’t override it. No additional imports, actions, or steps are required.

Concretely:
- Edit `.github/workflows/test.yaml`.
- After the existing `on:` configuration (after line 8, `workflow_dispatch:`), insert:

```yaml
permissions:
  contents: read
```

This will restrict the `GITHUB_TOKEN` to read‑only access to repo contents, which is sufficient for `actions/checkout` to fetch the code and for the tests to run.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
